### PR TITLE
Fix typos

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Yupa, WORK IN PROGRESS
 
 I'm activli working on it at the moment (2024.01.01 Mon 16:16) to have
-v1.0 for my personal usage but you never know with thos side projects.
+v1.0 for my personal usage but you never know with those side projects.
 I hope it will be finished soon as I would like to use it.
 
 MVP What I would like to have before calling this a v1.0?
@@ -16,7 +16,7 @@ For v2.0 I want to have Gemini support.
 
 - Gemini basic support (essentially what I have in gmi100).
 - History list.
-- Restoring previous brosing session.
+- Restoring previous browsing session.
 - Better error handling as many of them will just kill program.
 
 Test URIs:

--- a/lib/nav.h
+++ b/lib/nav.h
@@ -33,7 +33,7 @@ enum cmd {              // Possible commands input in nav prompt
 	CMD_TAB_CLOSE,  // Close current tab
 	//
 	CMD_SH_RAW,     // Run shell command on raw response body
-	CMD_SH_FMT,     // Run shell command on formatted respons
+	CMD_SH_FMT,     // Run shell command on formatted response
 };
 
 // Get command for BUF command string.  If BUF is empty or command

--- a/lib/net.h
+++ b/lib/net.h
@@ -1,4 +1,4 @@
-// Everythin socket, tcp, internet related.
+// Everything socket, tcp, internet related.
 
 #ifndef _NET_H
 #define _NET_H

--- a/lib/past.c
+++ b/lib/past.c
@@ -11,7 +11,7 @@
 // Like URI_AT but for currently active item.
 #define URI_I(past) URI_AT((past), (past)->i)
 
-// Lik URI_AT but for currently active item moved by OFFSET.
+// Like URI_AT but for currently active item moved by OFFSET.
 #define URI_OF(past, offset) URI_AT((past), (past)->i+(offset))
 
 struct past *
@@ -54,7 +54,7 @@ char *
 past_get(struct past *past, int offset)
 {
 	assert(past);
-	// TOOD(irek): Handle offset by more than 1?
+	// TODO(irek): Handle offset by more than 1?
 	assert(offset == 0 || offset == -1 || offset == 1);
 	if (!offset) {
 		return past->uri + URI_I(past);

--- a/lib/uri.h
+++ b/lib/uri.h
@@ -10,7 +10,7 @@
 
 #define URI_SIZ 1024            // Max size of URI
 
-// Protocols with cooresponding default ports.  In this lib protocol
+// Protocols with corresponding default ports.  In this lib protocol
 // and port are essentially the same thing.  OFC you can have custom
 // port number but protocol for it will still be a number being the
 // default port number.

--- a/main.c
+++ b/main.c
@@ -46,7 +46,7 @@ usage(void)
 	       , argv0);
 }
 
-// Get URI under INDEX link (1 based) from curently open tab.
+// Get URI under INDEX link (1 based) from currently open tab.
 static char *
 onlink(int index)
 {

--- a/test/past.t.c
+++ b/test/past.t.c
@@ -2,7 +2,7 @@
 #include "../lib/le.h"
 #include "../lib/past.h"
 
-// Usefull functin for debugging printing content of whole PAST
+// Useful function for debugging printing content of whole PAST
 // internal buffer marking ucrrently indexed element.  Not used
 // outside of debugging sessins.
 #pragma GCC diagnostic ignored "-Wunused-function"


### PR DESCRIPTION
Found via `codespell -S doc -L siz`